### PR TITLE
apps: removes proposal relicts

### DIFF
--- a/apps/ideas/forms.py
+++ b/apps/ideas/forms.py
@@ -22,7 +22,7 @@ CONFIRM_PUBLICITY_LABEL = _('I hereby confirm and agree that '
                             'my idea will be public once published. '
                             'I confirm that I have the right to share '
                             'the idea and the visual material '
-                            'used in this proposal.')
+                            'used.')
 ACCEPT_CONDITIONS_LABEL = _('I hereby agree to the {}terms'
                             ' of use{} of the Civic'
                             ' Europe idea challenge.')

--- a/apps/ideas/templates/civic_europe_ideas/includes/idea_detail_watch_btns.html
+++ b/apps/ideas/templates/civic_europe_ideas/includes/idea_detail_watch_btns.html
@@ -18,13 +18,13 @@
     </ul>
 </li>
 
-{% has_perm 'civic_europe_ideas.follow_idea' request.user idea as can_watch_proposal %}
-{% would_have_perm 'civic_europe_ideas.follow_idea' idea as could_watch_proposal %}
-{% if can_watch_proposal %}
+{% has_perm 'civic_europe_ideas.follow_idea' request.user idea as can_watch_idea %}
+{% would_have_perm 'civic_europe_ideas.follow_idea' idea as could_watch_idea %}
+{% if can_watch_idea %}
 <li class="nav-idea {{ xs_class }}">
     {% react_follows idea %}
 </li>
-{% elif could_watch_proposal %}
+{% elif could_watch_idea %}
 <li class="nav-idea {{ xs_class }}">
     <a href="{% url 'account_login' %}?next={% url 'idea-detail' slug=idea.slug %}" class="btn btn-follow" id="idea-watch">
         <i class="fa fa-eye" aria-hidden="true"></i>

--- a/apps/invites/templates/civic_europe_invites/invite_base.html
+++ b/apps/invites/templates/civic_europe_invites/invite_base.html
@@ -9,7 +9,7 @@
                 <h2>{% blocktrans with object=object.subject %} Do you want to collaborate on "{{ object }}"?{% endblocktrans %}</h2>
                 {{ form.non_field_errors }}
                 <p>
-                    {% trans "If you accept you will be able to edit the idea and appear as a team member in the proposal. You can edit the text altogether until the application deadline." %}
+                    {% trans "If you accept you will be able to edit the idea and appear as a team member. You can edit the text altogether until the application deadline." %}
                 </p>
                 {% block invite_action %}{% endblock %}
             </div>

--- a/apps/notifications/templates/civic_europe_notifications/emails/notify_followers_community_award.en.email
+++ b/apps/notifications/templates/civic_europe_notifications/emails/notify_followers_community_award.en.email
@@ -11,10 +11,7 @@ The idea "{{ idea.title }}" has won the community award.
 {% block content %}
 The idea "{{ idea.title }}" is the
 community award winner of the {{ site.name }} {{ idea.module.name }} competition.
-The team behind the idea is now invited to the idea challenge camp, where they
-can meet other inovators and team up to increase thier changes. Afterwards they
-can transform thier idea sketch into an proposal to participate in the final
-round.
+The idea will now be included in the shortlist and receive start-up funding.
 {% endblock %}
 
 {% block cta_url %}

--- a/apps/notifications/templates/civic_europe_notifications/emails/submit_idea_notification.en.email
+++ b/apps/notifications/templates/civic_europe_notifications/emails/submit_idea_notification.en.email
@@ -12,9 +12,9 @@ Thank you for submitting your project idea for the {{ site.name }} Idea Challeng
 
 {% block content %}
 <h3>What happens next?</h3>
-{% if idea.project.active_phase %}You can edit your proposal until <b>{{ idea.project.active_phase.end_date|date:"d F Y (H:i T)"}}</b>. {% endif %}Please note that all applications must be submitted <b>in English</b>, project proposals that are submitted in a language other than English will not be considered.
+{% if idea.project.active_phase %}You can edit your idea until <b>{{ idea.project.active_phase.end_date|date:"d F Y (H:i T)"}}</b>. {% endif %}Please note that all applications must be submitted <b>in English</b>, project ideas that are submitted in a language other than English will not be considered.
 <br /><br />
-Following the application deadline approximately 30 proposals will be shortlisted from among the submitted proposals that meet the selection and eligibility criteria and fit our call 2020. We will publish the shortlist on our online platform.
+Following the application deadline approximately 30 ideas will be shortlisted from among the submitted ideas that meet the selection and eligibility criteria and fit our call 2020. We will publish the shortlist on our online platform.
 <br /><br />
 After that our interdisciplinary jury selects <b>up to fifteen winning ideas</b> in autumn 2020. Find out more about the selection process and each phase of the idea challenge on www.civic-europe.de.
 <br /><br />


### PR DESCRIPTION
fixes #128 

There is still 
`cms/home/templates/cms_home/blocks/carousel_block.html:              {% include "cms_home/blocks/includes/proposal_carousel.html" with items=ideas %}
`
but I think its just the name and I didnt change this into idea_carousel, because I wasnt sure with urls .. 

Also there is still some proposal stuff in tests, but I think it works fine .. 


