### PR TITLE
WIP: apps/notifications: sending of community award notification

### DIFF
--- a/apps/notifications/admin.py
+++ b/apps/notifications/admin.py
@@ -60,6 +60,15 @@ class NotifyMixin:
         ] + super().get_urls()
 
     def _notify(self, request, *, display_winners=False):
+        """ Send out the notification.
+
+        If the 'notify winners' button is clicked, the winners notification
+        is sent out. If the 'notify shortlist' is clicked, for the ideas that
+        also won the community award (and were shortlisted because of that),
+        the community award notification is sent out, while for ideas that
+        are only shortlisted and did not win the community award, the
+        shortlist notification is sent out.
+        """
         if not self.has_change_permission(request):
             raise PermissionDenied
 

--- a/apps/notifications/templates/civic_europe_notifications/emails/notify_followers_community_award.en.email
+++ b/apps/notifications/templates/civic_europe_notifications/emails/notify_followers_community_award.en.email
@@ -11,7 +11,7 @@ The idea "{{ idea.title }}" has won the community award.
 {% block content %}
 The idea "{{ idea.title }}" is the
 community award winner of the {{ site.name }} {{ idea.module.name }} competition.
-The idea will now be included in the shortlist and receive start-up funding.
+Community award winners are automatically shortlist candidates for the idea challenge.
 {% endblock %}
 
 {% block cta_url %}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -45,14 +45,16 @@ Explains the civic europe specific notifications.
    - template: civic_europe_notifications/emails/notify_followers_winner
 
 7. NotifyFollowersOnShortlist
-   - sent to: followers of shortlisted ideas
-   - when: button in django-admin is clicked
+   - sent to: followers of shortlisted ideas, that did not win the community award
+   - when: button 'notify shortlist' in django-admin is clicked
    - not sent to: creators of shortlisted ideas
    - not sent to: followers who disabled the notifications
    - template: civic_europe_notifications/emails/notify_followers_shortlist
 
 
 8. NotifyFollowersOnCommunityAward
-   - is not sent at all
-   - is there in the templates and emails.py-code, but not added to the admin
+   - sent to: followers of shortlisted ideas, that also won the community award
+   - when: button 'notify shortlist' in django-admin is clicked
+   - not sent to: creators of shortlisted ideas
+   - not sent to: followers who disabled the notifications
    - template: civic_europe_notifications/emails/notify_followers_community_award


### PR DESCRIPTION
This already documents the behaviour as explained in #146, 
but we should also change the text of the community award notification email to fix that issue.

Let's already merge this and change the text later, when we get, though!