### PR TITLE
deps: Use wagtail 2.7 lts branch

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,7 +13,7 @@ feedparser==5.2.1
 micawber==0.5.1
 packaging==20.3
 raven==6.10.0
-wagtail==2.8.1
+wagtail==2.7.2
 whitenoise==5.0.1
 
 # Inherited a4-core requirements


### PR DESCRIPTION
Analogous to https://github.com/liqd/a4-opin/issues/1815

Run after deployment:
```
python manage.py migrate wagtailcore 0041_group_collection_permissions_verbose_name_plural
python manage.py migrate wagtailforms 0003_capitalizeverbose
```