### PR TITLE
settings: catch debug_toolbar import error

### DIFF
--- a/civic_europe/urls.py
+++ b/civic_europe/urls.py
@@ -81,13 +81,17 @@ urlpatterns += [
 if settings.DEBUG:
     from django.conf.urls.static import static
     from django.contrib.staticfiles.urls import staticfiles_urlpatterns
-    import debug_toolbar
-
-    urlpatterns = [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
-    ] + urlpatterns
 
     # Serve static and media files from development server
     urlpatterns += staticfiles_urlpatterns()
     urlpatterns += static(settings.MEDIA_URL,
                           document_root=settings.MEDIA_ROOT)
+
+    try:
+        import debug_toolbar
+    except ImportError:
+        pass
+    else:
+        urlpatterns = [
+            url(r'^__debug__/', include(debug_toolbar.urls)),
+        ] + urlpatterns


### PR DESCRIPTION
@rmader I copied it from A+, and I think it fixes #194 

But I don't get why it fails in the first place. Shouldn't it just not go in there on all the servers anyway, because of `if settings.DEBUG`?