### PR TITLE
renovate: Adjust automerge policy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,13 @@
     "config:base"
   ],
 
-  "automerge": false,
-  "major": {
-    "automerge": false
-  },
-  "devDependencies": {
+  "dependencies": {
+    "updateTypes": ["patch"],
     "automerge": true
   },
-  "digest": {
-    "enabled": false
+  "devDependencies": {
+    "updateTypes": ["minor", "patch"],
+    "automerge": true
   },
 
   "labels": [


### PR DESCRIPTION
Automerge patch updates, i.e. 1.0.x for "runtime" dependencies (it's
actually only used during build) and also minor updates, i.e. 1.x.x for
dev dependencies.