### PR TITLE
WIP: Ks 2021 02 integer field validation

### DIFF
--- a/apps/contrib/fields.py
+++ b/apps/contrib/fields.py
@@ -1,0 +1,21 @@
+import re
+
+from django.db import models
+from django.forms import fields
+
+
+class CustomIntegerField(models.IntegerField):
+
+    def formfield(self, **kwargs):
+        return super().formfield(**{
+            'form_class': CustomIntegerFormField,
+            **kwargs,
+        })
+
+
+class CustomIntegerFormField(fields.IntegerField):
+    """
+    overwrites re_decimal = re.compile(r'\.0*\s*$'), in order to raise
+    a validation error for decimal values with only 0s after decimal
+    """
+    re_decimal = re.compile(r'')

--- a/apps/ideas/forms.py
+++ b/apps/ideas/forms.py
@@ -99,9 +99,6 @@ class ApplicantSectionForm(BaseForm):
             'contact_email',
             'year_of_registration'
         ]
-        widgets = {
-            'year_of_registration': forms.TextInput(attrs={'maxlength': 20})
-        }
 
     def clean(self):
         cleaned_data = super().clean()
@@ -443,11 +440,6 @@ class FinanceSectionForm(BaseForm):
             'major_expenses',
             'duration'
         ]
-        widgets = {
-            'total_budget': forms.TextInput(attrs={'maxlength': 20}),
-            'budget_requested': forms.TextInput(attrs={'maxlength': 20}),
-            'duration': forms.TextInput(attrs={'maxlength': 20})
-        }
 
     def clean(self):
         cleaned_data = super().clean()

--- a/apps/ideas/models/sections/finances_section.py
+++ b/apps/ideas/models/sections/finances_section.py
@@ -2,6 +2,8 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import ugettext as _
 
+from apps.contrib import fields as custom_fields
+
 TOTAL_BUDGET_HELP = _('Please indicate your overall budget. '
                       'The total budget may (but does not '
                       'have to) include the applicant’s own '
@@ -29,7 +31,7 @@ DURATION_HELP = _('How many months will it take to implement your idea?')
 
 
 class FinancesSection(models.Model):
-    total_budget = models.IntegerField(
+    total_budget = custom_fields.CustomIntegerField(
         verbose_name=_('Total budget'),
         help_text=TOTAL_BUDGET_HELP,
         validators=[

--- a/civic_europe/assets/scss/components/_wizard.scss
+++ b/civic_europe/assets/scss/components/_wizard.scss
@@ -34,6 +34,15 @@
         font-size: $font-size-lg;
         font-weight: bold;
     }
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+        margin: 0; /* <-- Apparently some margin are still there even though it's hidden */
+    }
+
+    input[type="number"] {
+        -moz-appearance: textfield; /* Firefox */
+    }
 }
 
 


### PR DESCRIPTION
This is what I came up with..

IntegerFormField has a regex with trailing zeros, that is then sliced from the value. By overwriting this regex to be empty, the zeros arent removed anymore.. what do you think? Maybe all to complicated..

I only applied it to total_budget so far, so you can compare to old behaviour in budget_requested and didnt add the migration.