### PR TITLE
richtext/video-embed: span video over width and height

### DIFF
--- a/civic_europe/assets/scss/components/_blocks.scss
+++ b/civic_europe/assets/scss/components/_blocks.scss
@@ -241,3 +241,8 @@
 
     @extend .col-sm-4;
 }
+
+.rich-text iframe {
+    width: 100%;
+    height: 100%;
+}

--- a/cms/home/templates/cms_home/simple_page.html
+++ b/cms/home/templates/cms_home/simple_page.html
@@ -8,9 +8,15 @@
             <div class="col-md-8 offset-md-2">
                 <h1>{{ page.title }}</h1>
                 {% for block in page.body %}
-                <div class="clearfix">
-                	{% include_block block %}
-                </div>
+                  {% if block.block_type == 'text' %}
+                      <div class="rich-text">
+                          {% include_block block %}
+                      </div>
+                  {% else %}
+                      <div class="clearfix">
+                      	  {% include_block block %}
+                      </div>
+                  {% endif %}
                 {% endfor %}
             </div>
         </div>

--- a/cms/home/templates/cms_home/structured_text_page.html
+++ b/cms/home/templates/cms_home/structured_text_page.html
@@ -17,9 +17,15 @@
             <div class="col-md-7 structured-page-sections-container" data-spy="scroll" data-target="#structured-page-side-nav" data-offset="70">
                 {% for block in page.body %}
                 <span class="structured-page-section__anchor" id="section{{ forloop.counter }}"></span>
-                <div class="structured-page-section clearfix">
-                  {% include_block block %}
-                </div>
+                {% if block.block_type == 'section' %}
+                    <div class="structured-page-section clearfix rich-text">
+                      {% include_block block %}
+                    </div>
+                {% else %}
+                    <div class="structured-page-section clearfix">
+                      {% include_block block %}
+                    </div>
+                {% endif %}
                 {% endfor %}
             </div>
         </div>


### PR DESCRIPTION
closes #503 

based on this line:
https://github.com/liqd/a4-opin/blob/420261d2b72507925ea7cfab4db1291d66ec7567/home/templates/home/simple_page.html#L18

and here i am selecting `iframe` directly in css, instead of adding the following line (like in OPIN).
https://github.com/liqd/a4-opin/blob/da3766c759a031649466c74f07e696a8e4b5899d/euth_wagtail/assets/js/euth_wagtail.js#L88